### PR TITLE
Add basic CSI-2 to Avalon streaming decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # MIPI-RX
+
+Simple VHDL cores for receiving MIPI CSI-2 video streams and exposing them on an Avalon-ST interface.
+
+## Files
+
+- `rtl/csi2_pkg.vhd` – Common package definitions for the decoder.
+- `rtl/csi2_decoder.vhd` – Basic CSI-2 packet decoder with Avalon-ST output.
+
+The decoder expects byte aligned data from a D-PHY block and emits the packet payload over an Avalon streaming interface.

--- a/rtl/csi2_decoder.vhd
+++ b/rtl/csi2_decoder.vhd
@@ -1,0 +1,82 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.csi2_pkg.all;
+
+entity csi2_decoder is
+    generic (
+        LANES : positive := 1
+    );
+    port (
+        clk        : in  std_logic;
+        rst        : in  std_logic;
+        byte_data  : in  std_logic_vector(8*LANES-1 downto 0);
+        byte_valid : in  std_logic;
+        avst_data  : out std_logic_vector(7 downto 0);
+        avst_valid : out std_logic;
+        avst_ready : in  std_logic;
+        avst_sop   : out std_logic;
+        avst_eop   : out std_logic
+    );
+end entity csi2_decoder;
+
+architecture rtl of csi2_decoder is
+    type state_t is (S_IDLE, S_HEADER, S_PAYLOAD);
+    signal state       : state_t := S_IDLE;
+    signal header      : std_logic_vector(31 downto 0) := (others => '0');
+    signal byte_cnt    : integer range 0 to 3 := 0;
+    signal payload_cnt : unsigned(15 downto 0) := (others => '0');
+begin
+    process(clk)
+    begin
+        if rising_edge(clk) then
+            if rst = '1' then
+                state       <= S_IDLE;
+                header      <= (others => '0');
+                byte_cnt    <= 0;
+                payload_cnt <= (others => '0');
+                avst_data   <= (others => '0');
+                avst_valid  <= '0';
+                avst_sop    <= '0';
+                avst_eop    <= '0';
+            else
+                avst_sop   <= '0';
+                avst_eop   <= '0';
+                avst_valid <= '0';
+
+                case state is
+                    when S_IDLE =>
+                        if byte_valid = '1' then
+                            header(7 downto 0) <= byte_data(7 downto 0);
+                            byte_cnt <= 1;
+                            state    <= S_HEADER;
+                        end if;
+
+                    when S_HEADER =>
+                        if byte_valid = '1' then
+                            header(byte_cnt*8+7 downto byte_cnt*8) <= byte_data(7 downto 0);
+                            if byte_cnt = 3 then
+                                payload_cnt <= unsigned(header(23 downto 8));
+                                avst_sop    <= '1';
+                                byte_cnt    <= 0;
+                                state       <= S_PAYLOAD;
+                            else
+                                byte_cnt <= byte_cnt + 1;
+                            end if;
+                        end if;
+
+                    when S_PAYLOAD =>
+                        if byte_valid = '1' and avst_ready = '1' then
+                            avst_data  <= byte_data(7 downto 0);
+                            avst_valid <= '1';
+                            if payload_cnt = 1 then
+                                avst_eop <= '1';
+                                state    <= S_IDLE;
+                            end if;
+                            payload_cnt <= payload_cnt - 1;
+                        end if;
+                end case;
+            end if;
+        end if;
+    end process;
+end architecture rtl;

--- a/rtl/csi2_pkg.vhd
+++ b/rtl/csi2_pkg.vhd
@@ -1,0 +1,18 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package csi2_pkg is
+    constant C_MAX_LANES : natural := 4;
+
+    type avst_t is record
+        data  : std_logic_vector(7 downto 0);
+        valid : std_logic;
+        ready : std_logic;
+        sop   : std_logic;
+        eop   : std_logic;
+    end record avst_t;
+end package csi2_pkg;
+
+package body csi2_pkg is
+end package body csi2_pkg;


### PR DESCRIPTION
## Summary
- introduce a VHDL package with Avalon Streaming record types
- add a simple CSI-2 packet decoder emitting Avalon-ST payload
- document new IP core

## Testing
- `ghdl -s rtl/*.vhd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b1a12e7378832397fda9460ec45a2c